### PR TITLE
Set repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "ember server",
     "test": "ember try:testall"
   },
-  "repository": "",
+  "repository": "https://github.com/sgargan/ember-cli-autospy.git",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
This lets sites like [Ember Observer](https://emberobserver.com) display the repo URL.
